### PR TITLE
don't free memory in call_bcpl if allocation failed.

### DIFF
--- a/src/jst_abs.asm
+++ b/src/jst_abs.asm
@@ -2171,11 +2171,10 @@ call_bcpl:
 	
 	movem.l (sp)+,d7/a5/a6
 
-.nomem:
 	move.l d7,a1
 	move.l #BCPL_STACK,d0
 	JSRLIB	FreeMem
-
+.nomem:
 
 	movem.l (sp)+,d2-d7/a2-a6
 	rts


### PR DESCRIPTION
I haven't tested this, but it seems to me like freeing a null-pointer under 1.3 would lead to something bad.